### PR TITLE
Adds QEMU to Publish.yml

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -49,6 +49,12 @@ jobs:
             org.opencontainers.image.vendor="Better HPC LLC"
             org.opencontainers.image.ref.name="ghcr.io/better-hpc/slurm-env:${{ matrix.version }}"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
The publish CI requires QEMU for hardware emulation when building multi-architecture images.