### PR TITLE
Defines env variables in dockerfile instead of entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,10 @@ RUN groupadd -r slurm && useradd -r -g slurm slurm
 COPY --chown=slurm configs/$SLURM_VERSION/slurm.conf /etc/slurm/slurm.conf
 COPY --chown=slurm --chmod=600 configs/$SLURM_VERSION/slurmdbd.conf /etc/slurm/slurmdbd.conf
 
+# Setup dynamic environment variables
+RUN export CLUSTER_TYPE="slurm" \
+ && export CLUSTER_VERSION="$(sacctmgr --version)"
+
 # Launch Slurm and supporting services
 COPY entrypoint.sh /entrypoint.sh
 COPY tests /tests

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,9 +51,5 @@ wait_for 30 "scontrol ping | grep 'UP'"
 echo "(7/7) Starting slurmrestd"
 SLURM_JWT=daemon /usr/sbin/slurmrestd -u slurm 0.0.0.0:6820 &
 
-# Setup dynamic environment variables
-export CLUSTER_TYPE="slurm"
-export CLUSTER_VERSION="$(sacctmgr --version)"
-
 echo "System ready"
 exec "$@"


### PR DESCRIPTION
Moves the env variable definitions so they are defined even when the entrypoint is not run.